### PR TITLE
20240807 - feat : locastorage에 count가 저장되지 않고 0으로 초기화 되는 에러 수정

### DIFF
--- a/app/counterApp/page.tsx
+++ b/app/counterApp/page.tsx
@@ -3,27 +3,29 @@
 import { useEffect, useState } from "react";
 
 const CounterApp = () => {
-  const [count, setCount] = useState<number>(0);
+  const [count, setCount] = useState<number | null>(null);
 
   // 마운트 시, localstorage에 있는 값 불러오기
   useEffect(() => {
     const savedCount = localStorage.getItem("count");
     if (savedCount !== null) {
       setCount(parseInt(savedCount, 10));
+    } else {
+      setCount(0);
     }
   }, []);
 
   // count 상태값이 변하면, localstorage에 저장
   useEffect(() => {
-    localStorage.setItem("count", count.toString());
+    if (count !== null) localStorage.setItem("count", count.toString());
   }, [count]);
 
   const decreaseBtnClick = () => {
-    setCount(count - 1);
+    if (count !== null) setCount(count - 1);
   };
 
   const increaseBtnClick = () => {
-    setCount(count + 1);
+    if (count !== null) setCount(count + 1);
   };
 
   return (


### PR DESCRIPTION
1. useState 타입을 number와 null로 나올 수 있게 하고 초기값을 null로 수정.
2. 마운트 시, count에 null이라면 setCount를 사용해 0으로 변경.
3. count 값이 null이 나올 수가 있기 때문에, if (count !== null) 조건 추가.